### PR TITLE
Add ability to set default fps for mouse.move

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,15 +339,16 @@ Scrolls the wheel `delta` clicks. Sign indicates direction.
 
 <a name="mouse.move"/>
 
-## mouse.**move**(x, y, absolute=True, duration=0, steps_per_second=120.0)
+## mouse.**move**(x, y, absolute=True, duration=0, steps_per_second=None)
 
 [\[source\]](https://github.com/boppreh/mouse/blob/master/mouse/__init__.py#L109)
 
 
 Moves the mouse. If `absolute`, to position (x, y), otherwise move relative
 to the current position. If `duration` is non-zero, animates the movement.
-The fps of the animation is determined by 'steps_per_second', default is 120.
 
+Default fps of the animation is determined from `mouse.DEFAULT_STEPS_PER_SECOND`,
+can be overwritten or explicitly specified by the `steps_per_second` argument.
 
 <a name="mouse.drag"/>
 

--- a/mouse/__init__.py
+++ b/mouse/__init__.py
@@ -61,6 +61,8 @@ else:
 from ._mouse_event import ButtonEvent, MoveEvent, WheelEvent, LEFT, RIGHT, MIDDLE, X, X2, UP, DOWN, DOUBLE
 from ._generic import GenericListener as _GenericListener
 
+DEFAULT_STEPS_PER_SECOND = 120.0
+
 _pressed_events = set()
 class _MouseListener(_GenericListener):
     def init(self):
@@ -109,13 +111,15 @@ def wheel(delta=1):
     """ Scrolls the wheel `delta` clicks. Sign indicates direction. """
     _os_mouse.wheel(delta)
 
-def move(x, y, absolute=True, duration=0, steps_per_second=120.0):
+def move(x, y, absolute=True, duration=0, steps_per_second=None):
     """
     Moves the mouse. If `absolute`, to position (x, y), otherwise move relative
     to the current position. If `duration` is non-zero, animates the movement.
     """
     x = int(x)
     y = int(y)
+    if not steps_per_second:
+        steps_per_second = DEFAULT_STEPS_PER_SECOND
 
     # Requires an extra system call on Linux, but `move_relative` is measured
     # in millimiters so we would lose precision.


### PR DESCRIPTION
Can now set the default fps for the `mouse.move` function by setting `mouse.DEFAULT_STEPS_PER_SECONDS` variable.
Instead of having to explicitly pass `steps_per_second` for every call, or having to define a wrapper.