### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Then check the [API docs](https://github.com/boppreh/mouse#api) to see what feat
 ## Known limitations:
 
 - Events generated under Windows don't report device id (`event.device == None`). [#21](https://github.com/boppreh/keyboard/issues/21)
-- To avoid depending on X the Linux parts reads raw device files (`/dev/input/input*`) but this requries root.
+- To avoid depending on X the Linux parts reads raw device files (`/dev/input/input*`) but this requires root.
 - Other applications, such as some games, may register hooks that swallow all key events. In this case `mouse` will be unable to report events.
 
 
@@ -494,5 +494,5 @@ Plays a sequence of recorded events, maintaining the relative time
 intervals. If speed_factor is <= 0 then the actions are replayed as fast
 as the OS allows. Pairs well with [`record()`](#mouse.record).
 
-The parameters `include_*` define if events of that type should be inluded
+The parameters `include_*` define if events of that type should be included
 in the replay or ignored.

--- a/mouse/__init__.py
+++ b/mouse/__init__.py
@@ -38,7 +38,7 @@ Then check the [API docs](https://github.com/boppreh/mouse#api) to see what feat
 ## Known limitations:
 
 - Events generated under Windows don't report device id (`event.device == None`). [#21](https://github.com/boppreh/keyboard/issues/21)
-- To avoid depending on X the Linux parts reads raw device files (`/dev/input/input*`) but this requries root.
+- To avoid depending on X the Linux parts reads raw device files (`/dev/input/input*`) but this requires root.
 - Other applications, such as some games, may register hooks that swallow all key events. In this case `mouse` will be unable to report events.
 """
 # TODO
@@ -118,7 +118,7 @@ def move(x, y, absolute=True, duration=0, steps_per_second=120.0):
     y = int(y)
 
     # Requires an extra system call on Linux, but `move_relative` is measured
-    # in millimiters so we would lose precision.
+    # in millimeters so we would lose precision.
     position_x, position_y = get_position()
 
     if not absolute:
@@ -260,7 +260,7 @@ def play(events, speed_factor=1.0, include_clicks=True, include_moves=True, incl
     intervals. If speed_factor is <= 0 then the actions are replayed as fast
     as the OS allows. Pairs well with `record()`.
 
-    The parameters `include_*` define if events of that type should be inluded
+    The parameters `include_*` define if events of that type should be included
     in the replay or ignored.
     """
     last_time = None

--- a/mouse/_mouse_tests.py
+++ b/mouse/_mouse_tests.py
@@ -58,7 +58,7 @@ class TestMouse(unittest.TestCase):
     def flush_events(self):
         self.wait_for_events_queue()
         events = list(self.events)
-        # Ugly, but requried to work in Python2. Python3 has list.clear
+        # Ugly, but required to work in Python2. Python3 has list.clear
         del self.events[:]
         return events
 


### PR DESCRIPTION
There are small typos in:
- README.md
- mouse/__init__.py
- mouse/_mouse_tests.py

Fixes:
- Should read `requires` rather than `requries`.
- Should read `included` rather than `inluded`.
- Should read `required` rather than `requried`.
- Should read `millimeters` rather than `millimiters`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md